### PR TITLE
save the return value of `$stack` to align with object immutability a…

### DIFF
--- a/src/Framework/Middleware/Factory/ErrorHandlerMiddlewareFactory.php
+++ b/src/Framework/Middleware/Factory/ErrorHandlerMiddlewareFactory.php
@@ -43,7 +43,7 @@ class ErrorHandlerMiddlewareFactory implements ObjectFactoryInterface
         }
 
         foreach ($configuration->get('error_handlers') as $handler) {
-            $stack->withMiddleware($container->get($handler));
+            $stack = $stack->withMiddleware($container->get($handler));
         }
 
         return new ErrorHandlerMiddleware($stack);


### PR DESCRIPTION
…nd prevent empty error handler middleware
