### PR TITLE
Introduce generic Hydration traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ demo/
 build/
 .vscode
 composer.lock
+*.swp
+tags

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     "license": "MIT",
     "require": {
         "php": "^7.0",
-        "psr/http-message": "~1.0",
-        "container-interop/container-interop": "~1.1",
-        "zendframework/zend-diactoros": "~1.3",
+        "psr/http-message": "^1.0",
+        "container-interop/container-interop": "^1.1",
+        "zendframework/zend-diactoros": "^1.3",
         "roave/security-advisories": "dev-master",
         "http-interop/http-middleware": "0.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     "license": "MIT",
     "require": {
         "php": "^7.0",
-        "psr/http-message": "^1.0",
-        "container-interop/container-interop": "^1.1",
-        "zendframework/zend-diactoros": "^1.3",
+        "psr/http-message": "~1.0",
+        "container-interop/container-interop": "~1.1",
+        "zendframework/zend-diactoros": "~1.3",
         "roave/security-advisories": "dev-master",
         "http-interop/http-middleware": "0.4"
     },

--- a/src/Framework/Hydrator/Interfaces/HydratableInterface.php
+++ b/src/Framework/Hydrator/Interfaces/HydratableInterface.php
@@ -32,5 +32,5 @@ interface HydratableInterface
      *
      * @return array The extracted data
      */
-    public function extract(array $keys): array;
+    public function extract(array $keys = []): array;
 }

--- a/src/Framework/Hydrator/Interfaces/HydratableInterface.php
+++ b/src/Framework/Hydrator/Interfaces/HydratableInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Onion\Framework\Hydrator\Interfaces;
+
+/**
+ * An interface representing the methods provided by the hydration
+ * traits, that allow hydration and dehydration of the current object.
+ *
+ * Note that all (de)hydration is performed only on public methods/properties
+ *
+ * @package Onion\Framework\Hydrator\Interfaces
+ */
+interface HydratableInterface
+{
+    /**
+     * Populates the current object with the provided data, according to
+     * the used strategy
+     *
+     * @param array $data Data used to populate the object
+     *
+     * @return object A cloned, populated instance of the current object
+     */
+    public function hydrate(array $data);
+
+    /**
+     * Extract data from the current object. If $keys is provided
+     * it will retrieve only those keys, otherwise all "public"
+     * data will be extracted from the object.
+     *
+     * @param array $keys (Optional) List of specific keys to extract
+     *
+     * @return array The extracted data
+     */
+    public function extract(array $keys): array;
+}

--- a/src/Framework/Hydrator/MethodHydrator.php
+++ b/src/Framework/Hydrator/MethodHydrator.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Onion\Framework\Hydrator;
+
+/**
+ * Hydrates and extracts objects using getters and setters
+ */
+trait MethodHydrator
+{
+    /**
+     * Hydrates the object with the $data provided
+     *
+     * @param array $data Assoc array with param
+     *
+     * @return $this A hydrated copy of the object provided
+     */
+    public function hydrate(array $data)
+    {
+        $target = clone $this;
+        foreach ($data as $name => $value) {
+            // Transform underscored keys to camelCase
+            $method = str_replace('_', '', ucfirst(ucwords($name, '_')));
+            if (method_exists($target, 'set' . $method)) {
+                $target->{'set' . $method}(...(array) $value);
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * Extracts all data from the $object or extracts only
+     * the provided $keys
+     *
+     * @param array  $keys List of keys with which to filter the extracted keys
+     *
+     * @return array The extracted data
+     */
+    public function extract(array $keys = []): array
+    {
+        $data = [];
+
+        if ($keys === []) {
+            $reflection = new \ReflectionObject($this);
+            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if (0 === strpos($method->getName(), 'get')) {
+                    $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', substr($method->getName(), 3)))] =
+                        $method->invoke($this);
+                }
+            }
+
+            return $data;
+        }
+
+        foreach ($keys as $name) {
+            if (method_exists($this, 'get' . ucfirst(str_replace('_', '', ucwords($name))))) {
+                $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name))] = call_user_func([
+                    $this,
+                    'get' . str_replace('_', '', ucfirst(ucwords($name, '_')))
+                ]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/Framework/Hydrator/PropertyHydrator.php
+++ b/src/Framework/Hydrator/PropertyHydrator.php
@@ -37,8 +37,8 @@ trait PropertyHydrator
             return $data;
         }
 
-        foreach ($keys as $name => $value) {
-            $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name))] = $value;
+        foreach ($keys as $name) {
+            $data[$name] = $this->{str_replace('_', '', lcfirst(ucwords($name, '_')))};
         }
 
         return $data;

--- a/src/Framework/Hydrator/PropertyHydrator.php
+++ b/src/Framework/Hydrator/PropertyHydrator.php
@@ -29,8 +29,9 @@ trait PropertyHydrator
         $data = [];
         if ($keys === []) {
             $reflection = new \ReflectionObject($this);
-            foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $name => $value) {
-                $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name))] = $value;
+            foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+                $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $property->getName()))] =
+                    $property->getValue($this);
             }
 
             return $data;

--- a/src/Framework/Hydrator/PropertyHydrator.php
+++ b/src/Framework/Hydrator/PropertyHydrator.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Onion\Framework\Hydrator;
+
+trait PropertyHydrator
+{
+    /**
+     * @inheritdoc
+     */
+    public function hydrate(array $data)
+    {
+        $target = clone $this;
+        foreach ($data as $name => $value) {
+            $property = str_replace('_', '', lcfirst(ucwords($name, '_')));
+            if (property_exists($target, $property)) {
+                $target->$property = $value;
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function extract(array $keys = []): array
+    {
+        $data = [];
+        if ($keys === []) {
+            $reflection = new \ReflectionObject($this);
+            foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $name => $value) {
+                $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name))] = $value;
+            }
+
+            return $data;
+        }
+
+        foreach ($keys as $name => $value) {
+            $data[strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name))] = $value;
+        }
+
+        return $data;
+    }
+}

--- a/tests/Hydrator/MethodHydratorTest.php
+++ b/tests/Hydrator/MethodHydratorTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Hydrator;
+
+use \Onion\Framework\Hydrator\Interfaces\HydratableInterface;
+use \Onion\Framework\Hydrator\MethodHydrator;
+
+class MethodHydratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHydration()
+    {
+        /**
+         * @var HydratableInterface $hydrator
+         */
+        $testable = new class implements HydratableInterface
+        {
+            use MethodHydrator;
+
+            private $id;
+            private $name;
+            
+            public function getId(): int
+            {
+                return $this->id;
+            }
+
+            public function setId(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function setName(string $name)
+            {
+                $this->name = $name;
+            }
+        };
+
+        $result = $testable->hydrate([
+            'id' => 10,
+            'name' => 'George'
+        ]);
+
+        $this->assertNotSame($testable, $result);
+        $this->assertSame(10, $result->getId());
+        $this->assertSame('George', $result->getName());
+    }
+
+    public function testDehydration()
+    {
+        $testable = new class implements HydratableInterface
+        {
+            use MethodHydrator;
+
+            public function getId(): int { return 10; }
+            public function getName(): string { return 'John'; }
+        };
+
+        $this->assertSame([
+            'id' => 10,
+            'name' => 'John'
+        ], $testable->extract());
+    }
+
+    public function testNamingTransformation()
+    {
+        $testable = new class implements HydratableInterface
+        {
+            use MethodHydrator;
+
+            private $name = 'Jane';
+            public function getFirstName(): string
+            {
+                return (string) $this->name;
+            }
+        };
+
+       $this->assertSame(['first_name' => 'Jane'], $testable->extract(['first_name'])); 
+    }
+}

--- a/tests/Hydrator/PropertyHydratorTest.php
+++ b/tests/Hydrator/PropertyHydratorTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Hydrator;
+
+use Onion\Framework\Hydrator\Interfaces\HydratableInterface;
+use Onion\Framework\Hydrator\PropertyHydrator;
+
+class PropertyHydratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $testable;
+
+    public function setUp()
+    {
+
+    }
+
+    public function testHydration()
+    {
+        /**
+         * @var $testable HydratableInterface
+         */
+        $testable = new class implements HydratableInterface
+        {
+            use PropertyHydrator;
+
+            public $id;
+            public $name;
+        };
+        $result = $testable->hydrate([
+            'id' => 10,
+            'name' => 'George'
+        ]);
+        $this->assertNotSame($testable, $result);
+        $this->assertSame(10, $result->id);
+        $this->assertSame('George', $result->name);
+    }
+
+    public function testDehydration()
+    {
+        /**
+         * @var $testable HydratableInterface
+         */
+        $testable = new class implements HydratableInterface
+        {
+            use PropertyHydrator;
+
+            public $id = 10;
+            public $name = 'John';
+        };
+
+        $this->assertSame([
+            'id' => 10,
+            'name' => 'John'
+        ], $testable->extract());
+    }
+
+    public function testNamingTransformation()
+    {
+        /**
+         * @var $testable HydratableInterface
+         */
+        $testable = new class implements HydratableInterface
+        {
+            use PropertyHydrator;
+
+            public $firstName = 'Jane';
+        };
+
+        $this->assertArrayHasKey('first_name', $testable->extract());
+        $result = $testable->hydrate(['first_name' => 'Jenny']);
+        $this->assertSame('Jenny', $result->firstName);
+    }
+
+    public function testSelectiveExtraction()
+    {
+        /**
+         * @var $testable HydratableInterface
+         */
+        $testable = new class implements HydratableInterface
+        {
+            use PropertyHydrator;
+
+            public $firstName = 'Jane';
+        };
+
+        $this->assertSame(['first_name' => 'Jane'], $testable->extract(['first_name']));
+    }
+}


### PR DESCRIPTION
This PR introduces 2 new traits and 1 interface to provide a simple way of hydrating objects.

The interface is aimed to be a contract, indicating that the the object implementing it provides the necessary means for (de)hydration and the 2 traits are separate implementations of said contract:

 - `Hydrator\ProperyHydrator`: (de)hydrates an object using its `public` properties
 - `Hydrator\MethodHydrator`; (de)hydrates using the getters and setters of the object

Note that both strategies, at present, do a key transformation, i.e expect arrays to have `snake_case` keys and convert them to `camelCase`. The reverse transformation is applied when extracting.