### PR TITLE
Bugfix/exception bubbling

### DIFF
--- a/src/Framework/Application/Application.php
+++ b/src/Framework/Application/Application.php
@@ -41,14 +41,6 @@ class Application implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate = null): ResponseInterface
     {
-        try {
-            return $this->delegate->process($request);
-        } catch (\Throwable $ex) {
-            if ($delegate === null) {
-                throw $ex;
-            }
-
-            return $delegate->process($request->withAttribute('exception', $ex));
-        }
+        return $this->delegate->process($request);
     }
 }

--- a/src/Framework/Router/Router.php
+++ b/src/Framework/Router/Router.php
@@ -113,7 +113,7 @@ class Router implements Interfaces\RouterInterface, MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate = null): ResponseInterface
     {
-       /**
+        /**
         * @var array[] $route
         */
         $route = $this->match($request->getMethod(), $request->getUri());

--- a/src/Framework/Router/Router.php
+++ b/src/Framework/Router/Router.php
@@ -113,20 +113,16 @@ class Router implements Interfaces\RouterInterface, MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate = null): ResponseInterface
     {
-        try {
-            /**
-            * @var array[] $route
-            */
-            $route = $this->match($request->getMethod(), $request->getUri());
+       /**
+        * @var array[] $route
+        */
+        $route = $this->match($request->getMethod(), $request->getUri());
 
-            foreach ($route[3] as $name => $param) {
-                $request = $request->withAttribute($name, $param);
-            }
-
-            return $route[1]->process($request);
-        } catch (Exception\NotFoundException $ex) {
-            return $delegate->process($request);
+        foreach ($route[3] as $name => $param) {
+            $request = $request->withAttribute($name, $param);
         }
+
+        return $route[1]->process($request);
     }
 
     /**

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -84,28 +84,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app->process($this->prophesize(ServerRequestInterface::class)->reveal(), null);
     }
 
-    public function testDelegateInvocationOnException()
-    {
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $request->withAttribute()->willReturn(function () use ($request) {
-            return $request->reveal();
-        });
-        $this->stack->process(new TypeToken(RequestInterface::class), null)
-            ->willThrow(\Exception::class);
-
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(new AnyValueToken())->willThrow(new \Exception('Delegate Error'));
-
-        $app = new Application(
-            $this->stack->reveal(),
-            $this->emitter->reveal()
-        );
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Delegate Error');
-        $app->process($request->reveal(), $delegate->reveal());
-    }
-
     public function testApplicationFrameRun()
     {
         $request = $this->prophesize(ServerRequestInterface::class);


### PR DESCRIPTION
Targets #23 

- Removes the `try-catch` from `Application::process`
- Removes the `try-catch` from `Router::process`