### PR TITLE
Replace internal array structure-with-object

### DIFF
--- a/src/Framework/Dependency/Container.php
+++ b/src/Framework/Dependency/Container.php
@@ -25,11 +25,11 @@ final class Container implements AttachableContainer
     /**
      * Container constructor.
      *
-     * @param array $dependencies
+     * @param object $dependencies
      */
-    public function __construct(array $dependencies)
+    public function __construct(object $dependencies)
     {
-        $this->dependencies = json_decode(json_encode($dependencies), false);
+        $this->dependencies = $dependencies;
 
         if (isset($this->dependencies->shared)) {
             $this->shared = $this->dependencies->shared ?? [];

--- a/src/Framework/Dependency/Container.php
+++ b/src/Framework/Dependency/Container.php
@@ -17,8 +17,6 @@ use Psr\Container\NotFoundExceptionInterface;
 final class Container implements AttachableContainer
 {
     private $dependencies = [];
-    private $invokables = [];
-    private $factories = [];
     private $shared = [];
 
     /** @var ContainerInterface */
@@ -31,23 +29,12 @@ final class Container implements AttachableContainer
      */
     public function __construct(array $dependencies)
     {
-        $this->dependencies = $dependencies;
-        if (isset($this->dependencies['invokables'])) {
-            $this->invokables = $this->dependencies['invokables'];
-            unset($this->dependencies['invokables']);
-        }
+        $this->dependencies = json_decode(json_encode($dependencies), false);
 
-        if (isset($this->dependencies['factories'])) {
-            $this->factories = $this->dependencies['factories'];
-            unset($this->dependencies['factories']);
+        if (isset($this->dependencies->shared)) {
+            $this->shared = $this->dependencies->shared ?? [];
+            unset($this->dependencies->shared);
         }
-
-        if (isset($this->dependencies['shared'])) {
-            $this->shared = $this->dependencies['shared'] ?? [];
-            unset($this->dependencies['shared']);
-        }
-
-        $this->dependencies = array_merge($this->dependencies, $dependencies);
     }
 
     public function attach(ContainerInterface $container): void
@@ -70,16 +57,16 @@ final class Container implements AttachableContainer
     {
         $key = (string) $key;
 
-        if (array_key_exists($key, $this->dependencies)) {
-            return $this->dependencies[$key];
+        if (isset($this->dependencies->$key)) {
+            return $this->dependencies->$key;
         }
 
         try {
-            if (isset($this->invokables[$key])) {
+            if (isset($this->dependencies->invokables->$key)) {
                 return $this->retrieveInvokable($key);
             }
 
-            if (isset($this->factories[$key])) {
+            if (isset($this->dependencies->factories->$key)) {
                 return $this->retrieveFromFactory($key);
             }
 
@@ -113,9 +100,9 @@ final class Container implements AttachableContainer
     {
         $key = (string) $key;
         $exists = (
-            array_key_exists($key, $this->dependencies) ||
-            isset($this->dependencies['invokables'][$key]) ||
-            isset($this->dependencies['factories'][$key]) ||
+            isset($this->dependencies->$key) ||
+            isset($this->dependencies->invokables->$key) ||
+            isset($this->dependencies->factories->$key) ||
             class_exists($key)
         );
 
@@ -126,9 +113,9 @@ final class Container implements AttachableContainer
                 $ref = &$this->dependencies;
                 while ($keys !== []) {
                     $component = array_shift($keys);
-                    if (isset($ref[$component])) {
+                    if (isset($ref->$component)) {
                         $exists=true;
-                        $ref= &$ref[$component];
+                        $ref= &$ref->$component;
                         continue;
                     }
 
@@ -147,11 +134,11 @@ final class Container implements AttachableContainer
      * @throws \RuntimeException
      * @throws UnknownDependency
      */
-    private function retrieveInvokable(string $className)
+    private function retrieveInvokable(string $className): object
     {
-        $dependency = $this->invokables[$className];
+        $dependency = $this->dependencies->invokables->$className;
         if (is_object($dependency)) {
-            return $dependency;
+            return $this->enforceReturnType($className, $dependency);
         }
 
         if (!is_string($dependency)) {
@@ -167,7 +154,16 @@ final class Container implements AttachableContainer
             );
         }
 
-        return $this->enforceReturnType($className, $this->retrieveFromReflection($dependency));
+        $result = $this->retrieveFromReflection($dependency);
+        if (in_array($className, $this->shared, true)) {
+            if (!isset($this->dependencies->invokables)) {
+                $this->dependencies->invokables = new \stdClass;
+            }
+
+            $this->dependencies->invokables->{$className} = $result;
+        }
+
+        return $this->enforceReturnType($className, $result);
     }
 
     /**
@@ -175,7 +171,7 @@ final class Container implements AttachableContainer
      * @return mixed|object
      * @throws ContainerErrorException
      */
-    private function retrieveFromReflection(string $className)
+    private function retrieveFromReflection(string $className): object
     {
         $classReflection = new \ReflectionClass($className);
         if ($classReflection->getConstructor() === null) {
@@ -227,12 +223,10 @@ final class Container implements AttachableContainer
      * @param string $className
      * @return mixed
      */
-    private function retrieveFromFactory(string $className)
+    private function retrieveFromFactory(string $className): object
     {
-        $factory = $this->factories[$className];
-        if (!is_object($factory)) {
-            $factory = new $factory();
-        }
+        $factory = (new \ReflectionClass($this->dependencies->factories->$className))
+            ->newInstance();
 
         assert(
             $factory instanceof FactoryInterface,
@@ -246,8 +240,11 @@ final class Container implements AttachableContainer
          */
         $result = $this->enforceReturnType($className, $factory->build($this->delegate ?? $this));
         if (in_array($className, $this->shared, true)) {
-            $this->invokables[$className] = $result;
-            unset($this->factories[$className]);
+            if (!isset($this->dependencies->invokables)) {
+                $this->dependencies->invokables = new \stdClass;
+            }
+
+            $this->dependencies->invokables->{$className} = $result;
         }
 
         return $result;
@@ -264,26 +261,24 @@ final class Container implements AttachableContainer
         $stack = "$lead";
 
         assert(
-            isset($this->dependencies[$lead]),
+            isset($this->dependencies->$lead),
             new ContainerErrorException(
                 "No definition available for '{$stack}' inside container"
             )
         );
 
-        $component = $this->dependencies[$lead];
+        $component = $this->dependencies->$lead;
 
         foreach ($fragments as $fragment) {
             $stack .= ".$fragment";
             assert(
-                (
-                    is_array($component) || $component instanceof \ArrayAccess || $component instanceof \ArrayObject
-                ) && isset($component[$fragment]),
+                isset($component->$fragment),
                 new ContainerErrorException(
                     "No definition available for '{$stack}' inside container"
                 )
             );
 
-            $component = $component[$fragment];
+            $component = $component->$fragment;
         }
 
         return $component;
@@ -308,7 +303,7 @@ final class Container implements AttachableContainer
      * @return mixed
      * @throws ContainerErrorException
      */
-    private function enforceReturnType(string $identifier, $result)
+    private function enforceReturnType(string $identifier, object $result): object
     {
         if (is_string($identifier)) {
             if (class_exists($identifier) || interface_exists($identifier) ||

--- a/src/Framework/Dependency/Container.php
+++ b/src/Framework/Dependency/Container.php
@@ -185,7 +185,8 @@ final class Container implements AttachableContainer
         $constructorRef = $classReflection->getConstructor();
         $parameters = [];
         foreach ($constructorRef->getParameters() as $parameter) {
-            assert($parameter->hasType() || $parameter->isOptional() || $this->has($parameter->getName()),
+            assert(
+                $parameter->hasType() || $parameter->isOptional() || $this->has($parameter->getName()),
                 new ContainerErrorException(sprintf(
                     'Unable to resolve a class parameter "%s" of "%s::%s" without type ',
                     $parameter->getName(),

--- a/src/Framework/Dependency/Container.php
+++ b/src/Framework/Dependency/Container.php
@@ -225,13 +225,21 @@ final class Container implements AttachableContainer
      */
     private function retrieveFromFactory(string $className): object
     {
-        $factory = (new \ReflectionClass($this->dependencies->factories->$className))
+        $name = $this->dependencies->factories->$className;
+        assert(
+            is_string($name),
+            new ContainerErrorException(
+                "Registered factory for '{$className}' must be a valid FQCN, " . gettype($className) . ' given'
+            )
+        );
+
+        $factory = (new \ReflectionClass($name))
             ->newInstance();
 
         assert(
             $factory instanceof FactoryInterface,
             new ContainerErrorException(
-                "Factory for '$className' does not implement Dependency\\Interfaces\\FactoryInterface"
+                "Factory for '{$className}' does not implement Dependency\\Interfaces\\FactoryInterface"
             )
         );
 
@@ -307,11 +315,11 @@ final class Container implements AttachableContainer
     {
         if (is_string($identifier)) {
             if (class_exists($identifier) || interface_exists($identifier) ||
-                (function_exists("is_$identifier"))
+                (function_exists("is_{$identifier}"))
             ) {
                 assert(
                     $result instanceof $identifier ||
-                    (function_exists("is_$identifier") && call_user_func("is_$identifier", $result)),
+                    (function_exists("is_{$identifier}") && call_user_func("is_{$identifier}", $result)),
                     new ContainerErrorException(sprintf(
                         'Unable to verify that "%s" is of type "%s"',
                         is_object($result) ? get_class($result) : $result,

--- a/tests/Dependency/CacheAwareContainerTest.php
+++ b/tests/Dependency/CacheAwareContainerTest.php
@@ -18,7 +18,7 @@ class CacheAwareContainerTest extends \PHPUnit_Framework_TestCase
         {
             public function build(Container $container)
             {
-                return new \Onion\Framework\Dependency\Container([
+                return new \Onion\Framework\Dependency\Container((object) [
                     'bar' => 'baz'
                 ]);
             }

--- a/tests/Dependency/ContainerTest.php
+++ b/tests/Dependency/ContainerTest.php
@@ -19,7 +19,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 {
     public function testHasParameterCheck()
     {
-        $container = new Container(['bar' => 'baz']);
+        $container = new Container((object) ['bar' => 'baz']);
         $this->assertFalse($container->has('foo'));
         $this->assertTrue($container->has('bar'));
         $this->assertSame('baz', $container->get('bar'));
@@ -27,8 +27,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrievalOfInvokables()
     {
-        $container = new Container([
-            'invokables' => [
+        $container = new Container((object) [
+            'invokables' => (object) [
                 \stdClass::class => \stdClass::class
             ]
         ]);
@@ -40,8 +40,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrievalOfInvokablesWithBadMapping()
     {
-        $container = new Container([
-            'invokables' => [
+        $container = new Container((object) [
+            'invokables' => (object) [
                 \stdClass::class => 1
             ]
         ]);
@@ -52,8 +52,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrievalWhenUsingAFactory()
     {
-        $container = new Container([
-            'factories' => [
+        $container = new Container((object) [
+            'factories' => (object) [
                 \stdClass::class => FactoryStub::class
             ]
          ]);
@@ -66,8 +66,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testRetrievalOfSharedDependenciesFromFactory()
     {
         $container = new Container(
-            [
-                'factories' => [
+            (object) [
+                'factories' => (object) [
                     \stdClass::class => FactoryStub::class,
                 ],
                 'shared' => [
@@ -94,8 +94,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testRetrievalOfSharedDependenciesFromInvokables()
     {
         $container = new Container(
-            [
-                'invokables' => [
+            (object) [
+                'invokables' => (object) [
                     \stdClass::class => \stdClass::class
                 ],
                 'shared' => [
@@ -121,7 +121,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionOnNonExistingEntry()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
         $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
@@ -137,8 +137,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->expectException(ContainerExceptionInterface::class);
-        $container = new Container([
-            'factories' => [
+        $container = new Container((object) [
+            'factories' => (object) [
                 \stdClass::class => function () {
                 }
             ]
@@ -158,8 +158,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->expectException(ContainerExceptionInterface::class);
         $container = new Container(
-            [
-                'factories' => [
+            (object) [
+                'factories' => (object) [
                     \stdClass::class => \stdClass::class
                 ]
             ]
@@ -171,8 +171,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(UnknownDependency::class);
         $container = new Container(
-            [
-                'invokables' => [
+            (object) [
+                'invokables' => (object) [
                     \stdClass::class => 'FooBarDoesNotExistMan'
                 ]
             ]
@@ -192,8 +192,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->expectException(ContainerExceptionInterface::class);
         $container = new Container(
-            [
-                'invokables' => [
+            (object) [
+                'invokables' => (object) [
                     \SplFixedArray::class => \stdClass::class
                 ]
             ]
@@ -211,14 +211,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testDependencyResolutionFromReflection()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
         $this->assertInstanceOf(DependencyD::class, $container->get(DependencyD::class));
     }
 
     public function testDependencyLookupWhenBoundToInterface()
     {
-        $container = new Container([
-            'invokables' => [
+        $container = new Container((object) [
+            'invokables' => (object) [
                 DependencyC::class => DependencyD::class
             ]
         ]);
@@ -228,7 +228,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testDependencyWithParameterOfUnknownType()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
 
         $this->expectException(ContainerExceptionInterface::class);
         $container->get(DependencyE::class);
@@ -236,7 +236,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testResolutionBasedOnSimpleVariableName()
     {
-        $container = new Container([
+        $container = new Container((object) [
             'name' => 'foo'
         ]);
 
@@ -246,9 +246,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testResolutionWithComplexVariableName()
     {
-        $container = new Container([
-            'test' => [
-                'mock' => [
+        $container = new Container((object) [
+            'test' => (object) [
+                'mock' => (object) [
                     'name' => 'foo'
                 ]
             ]
@@ -261,7 +261,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionWhenComplexResolutionFails()
     {
-        $container = new Container(['foo' => ['bar'=> 'baz']]);
+        $container = new Container((object) ['foo' => (object) ['bar'=> 'baz']]);
         $this->assertFalse($container->has('foo.bar.baz'));
 //        $this->expectException(ContainerExceptionInterface::class);
 //        $this->expectExceptionMessage('Unable to resolve "foo.bar.baz"');
@@ -269,20 +269,20 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionOnComplexResolutionTypeMismatch()
     {
-        $container = new Container(['test' => ['mock' => ['name' => 5]]]);
+        $container = new Container((object) ['test' => (object) ['mock' => (object) ['name' => 5]]]);
         $this->assertSame('5', $container->get(DependencyG::class)->getName());
     }
 
     public function testUnknownInterfaceResolution()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
         $this->expectException(ContainerExceptionInterface::class);
         $container->get(DependencyF::class);
     }
 
     public function testExceptionOnConstructorParameterNotAvailable()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
         $this->expectException(ContainerExceptionInterface::class);
         $this->expectExceptionMessage(
             'Unable to resolve a class parameter "foo" of "Tests\Dependency\Doubles\DependencyH::__construct"'
@@ -292,14 +292,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrievalOfEmptyConstructorArgs()
     {
-        $container = new Container([]);
+        $container = new Container((object) []);
         $this->assertInstanceOf(DependencyI::class, $container->get(DependencyI::class));
     }
 
     public function testRetrievalOfDotString()
     {
-        $container = new Container([
-            'foo' => ['bar' => 'baz']
+        $container = new Container((object) [
+            'foo' => (object) ['bar' => 'baz']
         ]);
         $this->assertTrue($container->has('foo.bar'));
         $this->assertSame($container->get('foo.bar'), 'baz');

--- a/tests/Dependency/ContainerTest.php
+++ b/tests/Dependency/ContainerTest.php
@@ -52,10 +52,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrievalWhenUsingAFactory()
     {
-        $factory = new FactoryStub(\stdClass::class);
         $container = new Container([
             'factories' => [
-                \stdClass::class => $factory
+                \stdClass::class => FactoryStub::class
             ]
          ]);
 
@@ -69,7 +68,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container = new Container(
             [
                 'factories' => [
-                    \stdClass::class => new FactoryStub(new \stdClass())
+                    \stdClass::class => FactoryStub::class,
                 ],
                 'shared' => [
                     \stdClass::class
@@ -97,10 +96,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container = new Container(
             [
                 'invokables' => [
-                    \stdClass::class => new \stdClass()
+                    \stdClass::class => \stdClass::class
                 ],
                 'shared' => [
-                    \stdClass::class => \stdClass::class
+                    \stdClass::class
                 ]
             ]
         );

--- a/tests/Dependency/Doubles/FactoryStub.php
+++ b/tests/Dependency/Doubles/FactoryStub.php
@@ -10,7 +10,7 @@ class FactoryStub implements FactoryInterface
      * @var object
      */
     protected $returnVal;
-    public function __construct($return)
+    public function __construct($return = \stdClass::class)
     {
         $this->returnVal = $return;
     }


### PR DESCRIPTION
In PHP7.2 the objects are performing better than arrays when many items are in play which is the case if the container is used to contain, configurations and as application grows in size resulting in many definitions.